### PR TITLE
go through flink-info command path

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -338,6 +338,8 @@ public class CliFrontend {
 			LOG.info("Creating program plan dump");
 
 			Optimizer compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), configuration);
+
+			// [mcgg] entrypoint of getting Optimized Plan
 			FlinkPlan flinkPlan = ClusterClient.getOptimizedPlan(compiler, program, parallelism);
 
 			String jsonPlan = null;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -211,11 +211,14 @@ public abstract class ClusterClient<T> {
 				return getOptimizedPlan(compiler, prog.getPlanWithJars(), parallelism);
 			} else if (prog.isUsingInteractiveMode()) {
 				// temporary hack to support the optimizer plan preview
+
+				// [mcgg] Here using OptimizerPlanEnvironment, it has execute() method, which does not actually run the job, it returns an ProgramAbortException instead
 				OptimizerPlanEnvironment env = new OptimizerPlanEnvironment(compiler);
 				if (parallelism > 0) {
 					env.setParallelism(parallelism);
 				}
 
+				// [mcgg] go deeper
 				return env.getOptimizedPlan(prog);
 			} else {
 				throw new RuntimeException("Couldn't determine program mode.");

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -51,6 +51,7 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 		this.optimizerPlan = compiler.compile(plan);
 
 		// do not go on with anything now!
+		// [mcgg] here is how main() method in job is aborted
 		throw new ProgramAbortException();
 	}
 
@@ -80,6 +81,7 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 
 		setAsContext();
 		try {
+			// [mcgg] actually invokes main method in job's program, and will catch an ProgramAbortException, see line 55
 			prog.invokeInteractiveModeForExecution();
 		}
 		catch (ProgramInvocationException e) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -573,6 +573,7 @@ public class PackagedProgram {
 		}
 
 		try {
+			// [mcgg] because this main method is runnin in the OptimizerPlanEnvironment, so the execute() method will throw a ProgramAbortException instead of actually submit the operators to flink
 			mainMethod.invoke(null, (Object) args);
 		}
 		catch (IllegalArgumentException e) {


### PR DESCRIPTION
Went through `flink info` source code, here is the steps:
In `info()` method in `CliFrontend` class, it uses `OptimizerPlanEnvironment` as the running environment, so when the `main()` method in job's program is invoked, it will call another the `execute()` method in `OptimizerPlanEnvironment` class, and this `execute()` will throw a `ProgramAbortException` instead of actually submit the JobGraph into Flink.

https://github.com/mcgG/flink/projects/1#card-24566271